### PR TITLE
feat: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Savonet team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/mem_usage.c
+++ b/lib/mem_usage.c
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Savonet team
+//
+// SPDX-License-Identifier: MIT
+
 #include <caml/alloc.h>
 #include <caml/fail.h>
 #include <caml/memory.h>

--- a/lib/mem_usage.ml
+++ b/lib/mem_usage.ml
@@ -1,23 +1,8 @@
-(*****************************************************************************
-
-  Copyright 2022 Savonet team
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details, fully stated in the COPYING
-  file at the root of the liquidsoap distribution.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
-
- *****************************************************************************)
+(*
+ * SPDX-FileCopyrightText: 2022 - 2024 Savonet team
+ *
+ * SPDX-License-Identifier: MIT
+ *)
 
 type t = {
   total_virtual_memory : int;

--- a/lib/mem_usage.mli
+++ b/lib/mem_usage.mli
@@ -1,23 +1,8 @@
-(*****************************************************************************
-
-  Copyright 2022 Savonet team
-
-  This program is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details, fully stated in the COPYING
-  file at the root of the liquidsoap distribution.
-
-  You should have received a copy of the GNU General Public License
-  along with this program; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
-
- *****************************************************************************)
+(*
+ * SPDX-FileCopyrightText: 2022 - 2024 Savonet team
+ *
+ * SPDX-License-Identifier: MIT
+ *)
 
 type t = {
   total_virtual_memory : int;

--- a/mem_usage.opam
+++ b/mem_usage.opam
@@ -4,7 +4,7 @@ version: "0.1.0"
 synopsis: "Cross-platform stats about memory usage"
 maintainer: ["The Savonet Team <savonet-users@lists.sourceforge.net>"]
 authors: ["Romain Beauxis <toots@rastageeks.org>"]
-license: "GPL-2.0"
+license: "MIT"
 homepage: "https://github.com/savonet/ocaml-mem_usage"
 bug-reports: "https://github.com/savonet/ocaml-mem_usage/issues"
 depends: [

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,3 +1,9 @@
+(*
+ * SPDX-FileCopyrightText: 2022 - 2024 Savonet team
+ *
+ * SPDX-License-Identifier: MIT
+ *)
+
 let () =
   let {
     Mem_usage.total_virtual_memory;


### PR DESCRIPTION
## Summary

The license change was suggested in the [merge request discussion](https://github.com/ocaml/opam-repository/pull/25149#discussion_r1474727037), so I'd like to add the license to the repository.
I think the MIT license is fine for this purpose.

## Details

In addition to the LICENSE file, I generated a standard header for each source file using [`reuse`](https://github.com/fsfe/reuse-tool) with the following command:
```sh
reuse annotate \
  -l MIT \
  -y '2022-2024' \
  -c 'Savonet team' \
  --recursive \
  --skip-unrecognised \
  --merge-copyrights \
  lib \
  test
```